### PR TITLE
URGENT, PLEASE FIX ASAP: Removing inaccurate liveries.

### DIFF
--- a/livery.json
+++ b/livery.json
@@ -669,13 +669,6 @@
                     ]
                 },
                 {
-                    "name": "Comair Limited",
-                    "texture": [
-                        "/models/aircraft/premium/737_700/specular.jpg",
-                        "https://raw.githubusercontent.com/kolos26/GEOFS-LiverySelector/main/liveries/boeing_b737-700/comair.jpg"
-                    ]
-                },
-                {
                     "name": "Philippine Airlines",
                     "texture": [
                         "/models/aircraft/premium/737_700/specular.jpg",
@@ -771,13 +764,6 @@
                     "texture": [
                         "/models/aircraft/premium/737_700/specular.jpg",
                         "https://raw.githubusercontent.com/kolos26/GEOFS-LiverySelector/main/liveries/boeing_b737-700/wingo.png"
-                    ]
-                },
-                {
-                    "name": "Thai Airways",
-                    "texture": [
-                        "/models/aircraft/premium/737_700/specular.jpg",
-                        "https://raw.githubusercontent.com/kolos26/GEOFS-LiverySelector/main/liveries/boeing_b737-700/thai.png"
                     ]
                 },
                 {
@@ -1013,26 +999,10 @@
                     "credits": "GeoFS_TrailerGroup"
                 },
                 {
-                    "name": "Batik air",
-                    "texture": [
-                        "/models/aircraft/premium/737_700/specular.jpg",
-                        "https://raw.githubusercontent.com/kolos26/GEOFS-LiverySelector/main/liveries/boeing_b737-700/batik.png"
-                    ],
-                    "credits": "leonardᵗᵃⁿ"
-                },
-                {
                     "name": "Lion Air",
                     "texture": [
                         "/models/aircraft/premium/737_700/specular.jpg",
                         "https://raw.githubusercontent.com/kolos26/GEOFS-LiverySelector/main/liveries/boeing_b737-700/lion.png"
-                    ],
-                    "credits": "leonardᵗᵃⁿ"
-                },
-                {
-                    "name": "Singapore Airlines",
-                    "texture": [
-                        "/models/aircraft/premium/737_700/specular.jpg",
-                        "https://raw.githubusercontent.com/kolos26/GEOFS-LiverySelector/main/liveries/boeing_b737-700/singapore.png"
                     ],
                     "credits": "leonardᵗᵃⁿ"
                 },
@@ -1357,14 +1327,6 @@
                     "credits": "whois无名氏[Sino Wings Group]"
                 },
                 {
-                    "name": "Joly Airlines",
-                    "texture": [
-                        "/models/aircraft/premium/737_700/specular.jpg",
-                        "https://raw.githubusercontent.com/kolos26/GEOFS-LiverySelector/main/liveries/boeing_b737-700/jolyairlines.jpg"
-                    ],
-                    "credits": "Mathieu"
-                },
-                {
                     "name": "Air China (Red Peony livery)",
                     "texture": [
                         "/models/aircraft/premium/737_700/specular.jpg",
@@ -1445,22 +1407,6 @@
                     "credits": "Pom-Pom d'Cat"
                 },
                 {
-                    "name": "Reliance Group T7-LOTUS",
-                    "texture": [
-                        "/models/aircraft/premium/737_700/specular.jpg",
-                        "https://raw.githubusercontent.com/kolos26/GEOFS-LiverySelector/main/liveries/boeing_b737-700/LOTUSPNG.png"
-                    ],
-                    "credits": "Pom-Pom d'Cat"
-                },
-                {
-                    "name": "Skymark",
-                    "texture": [
-                        "/models/aircraft/premium/737_700/specular.jpg",
-                        "https://raw.githubusercontent.com/kolos26/GEOFS-LiverySelector/main/liveries/boeing_b737-700/JA73AA.png"
-                    ],
-                    "credits": "magu"
-                },
-                {
                     "name": "American Airlines (old desing)",
                     "texture": [
                         "https://raw.githubusercontent.com/kolos26/GEOFS-LiverySelector/main/liveries/boeing_b737-700/specular/americanold.png",
@@ -1493,14 +1439,6 @@
                     "credits": "747lover"
                 },
                 {
-                    "name": "Swiftair (Operated by European Air Transport)",
-                    "texture": [
-                        "/models/aircraft/premium/737_700/specular.jpg",
-                        "https://raw.githubusercontent.com/kolos26/GEOFS-LiverySelector/main/liveries/boeing_b737-700/Swiftair_x_DHL_-_B734_2.png"
-                    ],
-                    "credits": "Nichy"
-                },
-                {
                     "name": "Eastern Air Express",
                     "texture": [
                         "/models/aircraft/premium/737_700/specular.jpg",
@@ -1523,14 +1461,6 @@
                         "https://raw.githubusercontent.com/kolos26/GEOFS-LiverySelector/main/liveries/boeing_b737-700/N214WN_2.png"
                     ],
                     "credits": "Cranberry"
-                },
-                {
-                    "name": "Sriwijaya Air",
-                    "texture": [
-                        "/models/aircraft/premium/737_700/specular.jpg",
-                        "https://raw.githubusercontent.com/kolos26/GEOFS-LiverySelector/main/liveries/boeing_b737-700/Sriwijaya_Air_-_Boeing_735_4.png"
-                    ],
-                    "credits": "Nichy"
                 },
                 {
                     "name": "Jettime",
@@ -1621,14 +1551,6 @@
                     "credits": "Nichy"
                 },
                 {
-                    "name": "Greater Bay Airlines",
-                    "texture": [
-                        "/models/aircraft/premium/737_700/specular.jpg",
-                        "https://raw.githubusercontent.com/kolos26/GEOFS-LiverySelector/main/liveries/boeing_b737-700/b737-700201_9_3.jpg"
-                    ],
-                    "credits": "Burnin Hell"
-                },
-                {
                     "name": "Aeroflot",
                     "texture": [
                         "/models/aircraft/premium/737_700/specular.jpg",
@@ -1709,14 +1631,6 @@
                     "credits": "luca b"
                 },
                 {
-                    "name": "USAir",
-                    "texture": [
-                        "/models/aircraft/premium/737_700/specular.jpg",
-                        "https://raw.githubusercontent.com/kolos26/GEOFS-LiverySelector/main/liveries/boeing_b737-700/USAir_-_Boeing_737-400_1.png"
-                    ],
-                    "credits": "Nichy"
-                },
-                {
                     "name": "US Airways (USAir Heritage livery)",
                     "texture": [
                         "/models/aircraft/premium/737_700/specular.jpg",
@@ -1779,14 +1693,6 @@
                         "https://raw.githubusercontent.com/kolos26/GEOFS-LiverySelector/main/liveries/boeing_b737-700/sanghaiairlinesold.png"
                     ],
                     "credits": "HO1076[Sino Wings Group]"
-                },
-                {
-                    "name": "Aerosucre (HK-5370)",
-                    "texture": [
-                        "/models/aircraft/premium/737_700/specular.jpg",
-                        "https://raw.githubusercontent.com/kolos26/GEOFS-LiverySelector/main/liveries/boeing_b737-700/Aerosucre_HK-5370_-_Boeing_737-436SF.png"
-                    ],
-                    "credits": "Nichy"
                 },
                 {
                     "name": "Aerosucre (HK-5434)",
@@ -12737,13 +12643,6 @@
                     "name": "Citilink (Floral livery) 🥉",
                     "texture": [
                         "https://raw.githubusercontent.com/kolos26/GEOFS-LiverySelector/main/liveries/airbus_a320-214/citilinkfloral.png"
-                    ],
-                    "credits": "leonardᵗᵃⁿ"
-                },
-                {
-                    "name": "Aero Dili Timor Leste",
-                    "texture": [
-                        "https://raw.githubusercontent.com/kolos26/GEOFS-LiverySelector/main/liveries/airbus_a320-214/aerodili.png"
                     ],
                     "credits": "leonardᵗᵃⁿ"
                 },


### PR DESCRIPTION
Some liveries in the LS (particularly the ones with the 737-700) are inaccurate. I had kept the ones that are modeled after the 737-700 due to their near-identical appearance. Other than that, I removed a few liveries modeled on the A320 (yes, there is an A320 livery on the 737 for some reason), the 737-400 (with a stretched fuselage), and the 737-500 (with a shortened fuselage similar in size to the -200). Please merge this change before the next update.