### PR TITLE
URGENT: Correction of Japan Transocean Air Liveries Names

### DIFF
--- a/livery.json
+++ b/livery.json
@@ -23618,30 +23618,30 @@
                     "credits": "RYANAIR5719"
                 },
                 {
-                    "name": "Japan Transocean Air (Japanese Quail Winglets)",
+                    "name": "Japan Transocean Air (Okinawa Rail Winglets)",
                     "texture": [
-                        "https://raw.githubusercontent.com/kolos26/GEOFS-LiverySelector/main/liveries/boeing_b737-800/JA01RK.jpg"
+                        "https://raw.githubusercontent.com/RYANAIR5719/GeoFS-Liveries-Storage/refs/heads/main/boeing/737/-800/jal_ocean_rail.jpg"
                     ],
                     "credits": "RYANAIR5719"
                 },
                 {
                     "name": "Japan Transocean Air (Iriomote Cat Winglets)",
                     "texture": [
-                        "https://raw.githubusercontent.com/kolos26/GEOFS-LiverySelector/main/liveries/boeing_b737-800/JA03RK.jpg"
+                        "https://raw.githubusercontent.com/RYANAIR5719/GeoFS-Liveries-Storage/refs/heads/main/boeing/737/-800/jal_ocean_cat.jpg"
                     ],
                     "credits": "RYANAIR5719"
                 },
                 {
-                    "name": "Japan Transocean Air (Tsushima Cat Winglets)",
+                    "name": "Japan Transocean Air (Amani Rabbit Winglets)",
                     "texture": [
-                        "https://raw.githubusercontent.com/kolos26/GEOFS-LiverySelector/main/liveries/boeing_b737-800/JA02RK.jpg"
+                        "https://raw.githubusercontent.com/RYANAIR5719/GeoFS-Liveries-Storage/refs/heads/main/boeing/737/-800/jal_ocean_rabbit.jpg"
                     ],
                     "credits": "RYANAIR5719"
                 },
                 {
                     "name": "Japan Transocean Air",
                     "texture": [
-                        "https://raw.githubusercontent.com/kolos26/GEOFS-LiverySelector/main/liveries/boeing_b737-800/JA04RK.jpg"
+                        "https://raw.githubusercontent.com/RYANAIR5719/GeoFS-Liveries-Storage/refs/heads/main/boeing/737/-800/jal_ocean.jpg"
                     ],
                     "credits": "RYANAIR5719"
                 },


### PR DESCRIPTION
I may have made a terrible mistake when naming these liveries, which was caused by the misidentification of the species that the animals on the winglets belonged to. I have now corrected this issue, and hope to see this merged soon.